### PR TITLE
Modify SpongeMock to accept sentences

### DIFF
--- a/index.go
+++ b/index.go
@@ -46,7 +46,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	content := SlackRequest{
-		Text: 		 params.Get("text"),
+		Text:        params.Get("text"),
 		ResponseURL: params.Get("response_url"),
 	}
 
@@ -54,7 +54,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		content.ResponseURL,
 		&SlackResponse{
 			ResponseType: "in_channel",
-			Text: 		  SpongeMock(content.Text),
+			Text:         SpongeMock(content.Text),
 		},
 	)
 }
@@ -78,7 +78,7 @@ func SpongeMock(sentence string) string {
 				continue
 			}
 
-			if i % 2 == 0 {
+			if i%2 == 0 {
 				if char != 'i' {
 					buf[i] -= 32
 				}

--- a/index_test.go
+++ b/index_test.go
@@ -1,7 +1,6 @@
 package handler_test
 
 import (
-	"strings"
 	"testing"
 
 	"gotest.tools/assert"
@@ -21,6 +20,9 @@ func TestSpongeMock(t *testing.T) {
 			testStr:     "",
 			expectedStr: "",
 		}, {
+			testStr:     "  test  ",
+			expectedStr: "  TeSt  ",
+		}, {
 			testStr:     "こんにちは",
 			expectedStr: "こんにちは",
 		}, {
@@ -39,14 +41,6 @@ func TestSpongeMock(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		splitContent := strings.Split(test.testStr, " ")
-		var res []string
-
-		for _, word := range splitContent {
-			res = append(res, handler.SpongeMock(word))
-		}
-
-		buf := strings.Join(res, " ")
-		assert.Equal(t, buf, test.expectedStr)
+		assert.Equal(t, handler.SpongeMock(test.testStr), test.expectedStr)
 	}
 }


### PR DESCRIPTION
Moving word split logic into SpongeMock provides a cleaner interface
and small performance optomization from avoiding the use of 'append'