### PR TITLE
Fix mocking for phrases with numbers

### DIFF
--- a/index.go
+++ b/index.go
@@ -80,11 +80,11 @@ func SpongeMock(sentence string) string {
 
 			if i%2 == 0 {
 				if char != 'i' {
-					buf[i] -= 32
+					buf[i] = unicode.ToUpper(char)
 				}
 			} else {
 				if char == 'l' {
-					buf[i] -= 32
+					buf[i] = unicode.ToUpper(char)
 				}
 			}
 		}

--- a/index_test.go
+++ b/index_test.go
@@ -37,6 +37,18 @@ func TestSpongeMock(t *testing.T) {
 		}, {
 			testStr:     "<USERID|User>",
 			expectedStr: "<USERID|User>",
+		}, {
+			testStr:     "20",
+			expectedStr: "20",
+		}, {
+			testStr:     "20_20",
+			expectedStr: "20_20",
+		}, {
+			testStr:     "2020",
+			expectedStr: "2020",
+		}, {
+			testStr:     "2",
+			expectedStr: "2",
 		},
 	}
 


### PR DESCRIPTION
## What

Fixes #7 

## Notes

Use `unicode.ToUpper` rather than subtracting from runes